### PR TITLE
Add cross-domain permissions to Firefox manifest

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
   "license": "MPL 2.0",
   "version": "0.1",
   "lib": "firefox",
+  "permissions": {
+    "cross-domain-content": [ "https://chronicle.dev.mozaws.net/" ]
+  },
   "preferences": [
     {
         "name": "url",


### PR DESCRIPTION
Otherwise it don't work!
