### PR TITLE
Use single config

### DIFF
--- a/chrome/background.html
+++ b/chrome/background.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
 <head>
+  <script src='config.js'></script>
   <script src='main.js'></script>
 </head>
 <body>

--- a/chrome/config.js
+++ b/chrome/config.js
@@ -1,0 +1,3 @@
+var config = {
+  chronicleServer: 'https://chronicle.dev.mozaws.net'
+}

--- a/chrome/main.js
+++ b/chrome/main.js
@@ -1,8 +1,5 @@
-var SERVER_URL = 'https://chronicle.dev.mozaws.net';
-var CREATE_VISIT_ENDPOINT = SERVER_URL + '/v1/visits';
-
 chrome.browserAction.onClicked.addListener(function (tab) {
-  chrome.tabs.query({ url: SERVER_URL + '/*' }, function (tabs) {
+  chrome.tabs.query({ url: config.chronicleServer + '/*' }, function (tabs) {
     // if we already have an open chronicle tab, navigate to it
     if (tabs.length > 0) {
       var target = tabs[0];
@@ -12,7 +9,7 @@ chrome.browserAction.onClicked.addListener(function (tab) {
     }
     // otherwise open a new tab to chronicle
     else {
-      chrome.tabs.create( { url: SERVER_URL, active: true });
+      chrome.tabs.create( { url: config.chronicleServer, active: true });
     }
   });
 });

--- a/data/content_scripts/config.js
+++ b/data/content_scripts/config.js
@@ -1,0 +1,1 @@
+../../chrome/config.js

--- a/data/content_scripts/visit.js
+++ b/data/content_scripts/visit.js
@@ -1,6 +1,3 @@
-var SERVER_URL = 'https://chronicle.dev.mozaws.net';
-var CREATE_VISIT_ENDPOINT = SERVER_URL + '/v1/visits';
-
 function Visit(url, title, visitedAt) {
   this.url = url
   this.title = title;
@@ -11,7 +8,7 @@ Visit.prototype.save = function() {
   var deferred = P.defer();
   var xhr = new XMLHttpRequest();
   var body = JSON.stringify({ url: this.url, title: this.title, visitedAt: this.visitedAt });
-  xhr.open('POST', CREATE_VISIT_ENDPOINT, true);
+  xhr.open('POST', config.chronicleServer + '/v1/visits', true);
   xhr.setRequestHeader('Content-type', 'application/json');
   xhr.onreadystatechange = function() {
     if(xhr.readyState === 4) {

--- a/firefox/main.js
+++ b/firefox/main.js
@@ -7,6 +7,7 @@ var self = require('self');
 var contentScripts = [
   self.data.url('lib/p.js'),
   self.data.url('lib/almond.js'),
+  self.data.url('content_scripts/config.js'),
   self.data.url('content_scripts/visit.js'),
   self.data.url('content_scripts/main.js'),
 ];

--- a/manifest.json
+++ b/manifest.json
@@ -16,6 +16,7 @@
       "js": [
         "data/lib/p.js",
         "data/lib/almond.js",
+        "data/content_scripts/config.js",
         "data/content_scripts/visit.js",
         "data/content_scripts/main.js"
       ]


### PR DESCRIPTION
For now, it contains the server URL. It's going to hard to make these user configurable on the fly because for the firefox add-on, this origin needs to be in the manifest.

Should be merged after https://github.com/mozilla/chronicle-addon/pull/6 and https://github.com/mozilla/chronicle-addon/pull/5.
